### PR TITLE
Add the Azure Boards badge to the README

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,0 +1,1 @@
+[![Board Status](https://dev.azure.com/aiw-devops/d3dd4eea-c55c-4e4f-92e7-752e4a7c970b/fed9a397-93b2-4414-bbc5-92f79631ec3a/_apis/work/boardbadge/f4546df8-be57-41d4-b873-3923bb61bf72)](https://dev.azure.com/aiw-devops/d3dd4eea-c55c-4e4f-92e7-752e4a7c970b/_boards/board/t/fed9a397-93b2-4414-bbc5-92f79631ec3a/Microsoft.RequirementCategory)


### PR DESCRIPTION
Add the Azure Boards badge for the board used to track the work for this repository. Fixes [AB#1875](https://dev.azure.com/aiw-devops/d3dd4eea-c55c-4e4f-92e7-752e4a7c970b/_workitems/edit/1875). See the [status badge configuration](https://aka.ms/azureboardsgithub-badge) documentation for more information.